### PR TITLE
Add *.a to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .dub
 *-test-lib*
 dub.selections.json
+
+# Compiled Static libraries
+*.a


### PR DESCRIPTION
Ignore compiled Static Libraries in git.

I'd like to add the barcode library to the submodules.
https://github.com/bpfkorea/agora/issues/1229